### PR TITLE
Fix inappropriate property names: infl_form, infl_type (#24)

### DIFF
--- a/ipadic/build.py
+++ b/ipadic/build.py
@@ -43,12 +43,12 @@ def build_dict(dicdir, enc, outdir=u'.'):
                 line = line.rstrip()
                 surface, left_id, right_id, cost, \
                 pos_major, pos_minor1, pos_minor2, pos_minor3, \
-                infl_form, infl_type, base_form, reading, phonetic = \
+                infl_type, infl_form, base_form, reading, phonetic = \
                     line.split(',')
                 part_of_speech = ','.join([pos_major, pos_minor1, pos_minor2, pos_minor3])
                 morph_id = len(surfaces)
                 surfaces.append((surface.encode('utf8'), pack('I', morph_id)))
-                entries[morph_id] = (surface, int(left_id), int(right_id), int(cost), part_of_speech, infl_form, infl_type, base_form, reading, phonetic)
+                entries[morph_id] = (surface, int(left_id), int(right_id), int(cost), part_of_speech, infl_type, infl_form, base_form, reading, phonetic)
     inputs = sorted(surfaces)  # inputs must be sorted.
 
     assert len(surfaces) == len(entries)

--- a/janome/dic.py
+++ b/janome/dic.py
@@ -198,12 +198,12 @@ class UserDictionary(Dictionary):
                 line = line.rstrip()
                 surface, left_id, right_id, cost, \
                 pos_major, pos_minor1, pos_minor2, pos_minor3, \
-                infl_form, infl_type, base_form, reading, phonetic = \
+                infl_type, infl_form, base_form, reading, phonetic = \
                     line.split(',')
                 part_of_speech = ','.join([pos_major, pos_minor1, pos_minor2, pos_minor3])
                 morph_id = len(surfaces)
                 surfaces.append((surface.encode('utf8'), pack('I', morph_id)))
-                entries[morph_id] = (surface, int(left_id), int(right_id), int(cost), part_of_speech, infl_form, infl_type, base_form, reading, phonetic)
+                entries[morph_id] = (surface, int(left_id), int(right_id), int(cost), part_of_speech, infl_type, infl_form, base_form, reading, phonetic)
         inputs = sorted(surfaces)  # inputs must be sorted.
         assert len(surfaces) == len(entries)
         fst = create_minimum_transducer(inputs)

--- a/janome/lattice.py
+++ b/janome/lattice.py
@@ -51,20 +51,20 @@ class Node(BaseNode):
     """
     __slots__ = [
         'surface', 'left_id', 'right_id', 'cost',
-        'part_of_speech', 'infl_form', 'infl_type',
+        'part_of_speech', 'infl_type', 'infl_form',
         'base_form', 'reading', 'phonetic', 'node_type'
     ]
 
     def __init__(self, dict_entry, node_type=NodeType.SYS_DICT):
         super(Node, self).__init__()
-        surface, left_id, right_id, cost, part_of_speech, infl_form, infl_type, base_form, reading, phonetic = dict_entry
+        surface, left_id, right_id, cost, part_of_speech, infl_type, infl_form, base_form, reading, phonetic = dict_entry
         self.surface = surface
         self.left_id = left_id
         self.right_id = right_id
         self.cost = cost
         self.part_of_speech = part_of_speech
-        self.infl_form = infl_form
         self.infl_type = infl_type
+        self.infl_form = infl_form
         self.base_form = base_form
         self.reading = reading
         self.phonetic = phonetic
@@ -73,7 +73,7 @@ class Node(BaseNode):
     def __str__(self):
         return "(%s,%s,%s,%d,%s,%s,%s,%s,%s,%s) [back_pos=%d,back_index=%d]" % \
                (self.surface, self.left_id, self.right_id, self.cost, self.part_of_speech,
-                self.infl_form, self.infl_type, self.base_form, self.reading, self.phonetic,
+                self.infl_type, self.infl_form, self.base_form, self.reading, self.phonetic,
                 self.back_pos, self.back_index)
 
 

--- a/janome/tokenizer.py
+++ b/janome/tokenizer.py
@@ -26,8 +26,8 @@ class Token:
     def __init__(self, node):
         self.surface = node.surface
         self.part_of_speech = node.part_of_speech
-        self.infl_form = node.infl_form
         self.infl_type = node.infl_type
+        self.infl_form = node.infl_form
         self.base_form = node.base_form
         self.reading = node.reading
         self.phonetic = node.phonetic
@@ -36,13 +36,13 @@ class Token:
     def __str__(self):
         if PY3:
             return '%s\t%s,%s,%s,%s,%s,%s' % \
-               (self.surface, self.part_of_speech, self.infl_form, self.infl_type, self.base_form, self.reading, self.phonetic)
+               (self.surface, self.part_of_speech, self.infl_type, self.infl_form, self.base_form, self.reading, self.phonetic)
         else:
             return '%s\t%s,%s,%s,%s,%s,%s' % \
                (self.surface.encode('utf-8'),
                 self.part_of_speech.encode('utf-8'),
-                self.infl_form.encode('utf-8'),
                 self.infl_type.encode('utf-8'),
+                self.infl_form.encode('utf-8'),
                 self.base_form.encode('utf-8'),
                 self.reading.encode('utf-8'),
                 self.phonetic.encode('utf-8'))

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -122,7 +122,7 @@ class TestTokenizer(unittest.TestCase):
 
     def _check_token(self, token, surface, detail, node_type):
         self.assertEqual(surface, token.surface)
-        self.assertEqual(detail, ','.join([token.part_of_speech,token.infl_form,token.infl_type,token.base_form,token.reading,token.phonetic]))
+        self.assertEqual(detail, ','.join([token.part_of_speech,token.infl_type,token.infl_form,token.base_form,token.reading,token.phonetic]))
         if PY3:
             self.assertEqual(surface + '\t' + detail, str(token))
         else:


### PR DESCRIPTION
```
12:06 $ python
Python 2.7.10 (default, Oct 23 2015, 19:19:21)
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from janome.tokenizer import Tokenizer
>>> t = Tokenizer()
>>> data1 = (u"尼崎に住んでると言った。")
>>> for token in t.tokenize(data1):
...     print(token.infl_form)
...
*
*
連用タ接続
基本形
*
連用タ接続
基本形
*
>>> for token in t.tokenize(data1):
...     print(token.infl_type)
...
*
*
五段・マ行
一段
*
五段・ワ行促音便
特殊・タ
*
```