### PR TITLE
fix Windows install Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if not os.path.exists('sysdic') and os.path.exists(os.path.join('ipadic', 'sysdi
 version = '0.3.2-dev'
 name = 'janome'
 
-with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.rst')) as f:
+with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 import sys
+from io import open
 
 sys.path.append('./janome')
 sys.path.append('./tests')


### PR DESCRIPTION
Pythonでのインストール時に、文字コードに起因するエラーを直すため、setup.pyでファイルを開く箇所の文字コードを明示するように変更しました。
```PS C:\Users\takeshi> pip install janome
Collecting janome
  Using cached Janome-0.3.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\ninomiyt\AppData\Local\Temp\pip-build-amquly5i\janome\setup.py", line 22, in <module>
        long_description = f.read()
    UnicodeDecodeError: 'cp932' codec can't decode byte 0x81 in position 853: illegal multibyte sequence

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in C:\Users\ninomiyt\AppData\Local\Temp\pip-build-amquly5i\janome\
```