### PR TITLE
Add TokenCountFilter

### DIFF
--- a/examples/usage_analyzer.py
+++ b/examples/usage_analyzer.py
@@ -7,6 +7,7 @@ from janome.tokenfilter import *
 import logging
 logging.basicConfig(level='INFO')
 
+print(u'Analyzer example:')
 text = u'蛇の目はPure Ｐｙｔｈｏｎな形態素解析器です。'
 char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter(u'蛇の目', u'janome')]
 tokenizer = Tokenizer()
@@ -14,3 +15,11 @@ token_filters = [CompoundNounFilter(), LowerCaseFilter()]
 a = Analyzer(char_filters, tokenizer, token_filters)
 for token in a.analyze(text):
     print(token)
+
+print('')
+print(u'Analyzer example: Count nouns with POSKeepFilter and TokenCountFilter')
+text = u'すもももももももものうち'
+token_filters = [POSKeepFilter('名詞'), TokenCountFilter()]
+a = Analyzer(token_filters=token_filters)
+for k, v in a.analyze(text):
+    print('%s: %d' % (k, v))

--- a/janome/tokenfilter.py
+++ b/janome/tokenfilter.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 
 class TokenFilter(object):
     u"""
@@ -140,7 +141,7 @@ class ExtractAttributeFilter(TokenFilter):
     """
     def __init__(self, att):
         u"""
-        Initialize ExtractAttributeTokenFilter object.
+        Initialize ExtractAttributeFilter object.
 
         :param att: attribute name should be extraced from a token. valid values for *att* are 'surface', 'part_of_speech', 'infl_type', 'infl_form', 'base_form', 'reading' and 'phonetic'.
         """
@@ -151,3 +152,28 @@ class ExtractAttributeFilter(TokenFilter):
     def apply(self, tokens):
         for token in tokens:
             yield getattr(token, self.att)
+
+
+class TokenCountFilter(TokenFilter):
+    u"""
+    An TokenCountFilter counts word frequency. Here, 'word' means an attribute of Token.
+
+    **NOTES** This filter must placed the last of token filter chain because return values are word-count pairs but not tokens.
+
+    Added in *version 0.3.5*
+    """
+    def __init__(self, att='surface'):
+        u"""
+        Initialize TokenCountFilter object.
+
+        :param att: attribute name should be extraced from a token. valid values for *att* are 'surface', 'part_of_speech', 'infl_type', 'infl_form', 'base_form', 'reading' and 'phonetic'.
+        """
+        if att not in ['surface', 'part_of_speech', 'infl_type', 'infl_form', 'base_form', 'reading', 'phonetic']:
+            raise Exception('Unknown attribute name: %s' % att)
+        self.att = att
+
+    def apply(self, tokens):
+        token_counts = defaultdict(int)
+        for token in tokens:
+            token_counts[getattr(token, self.att)] += 1
+        return ((k, v) for k, v in sorted(token_counts.items(), key=lambda x: x[1], reverse=True))

--- a/tests/test_tokenfilter.py
+++ b/tests/test_tokenfilter.py
@@ -85,5 +85,34 @@ class TestTokenFilter(unittest.TestCase):
             ExtractAttributeFilter('foo')
 
 
+    def test_count_token_filter(self):
+        tf = TokenCountFilter()
+        d = dict(tf.apply(self.t.tokenize(u'すもももももももものうち')))
+        self.assertEqual(1, d[u'すもも'])
+        self.assertEqual(2, d[u'もも'])
+        self.assertEqual(2, d[u'も'])
+        self.assertEqual(1, d[u'の'])
+        self.assertEqual(1, d[u'うち'])
+
+        counts = list(map(lambda x: x[1], tf.apply(self.t.tokenize(u'すもももももももものうち'))))
+        self.assertEqual([2,2,1,1,1], counts)
+
+        tf = TokenCountFilter('base_form')
+        d = dict(tf.apply(self.t.tokenize(u'CountFilterで簡単に単語数が数えられます')))
+        self.assertEqual(1, d[u'CountFilter'])
+        self.assertEqual(1, d[u'で'])
+        self.assertEqual(1, d[u'簡単'])
+        self.assertEqual(1, d[u'に'])
+        self.assertEqual(1, d[u'単語'])
+        self.assertEqual(1, d[u'数'])
+        self.assertEqual(1, d[u'が'])
+        self.assertEqual(1, d[u'数える'])
+        self.assertEqual(1, d[u'られる'])
+        self.assertEqual(1, d[u'ます'])
+
+        # invalid attribute name
+        with self.assertRaises(Exception):
+            TokenCountFilter('foo')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
New TokenFilter to count frequenies of words.

Usage:

```
>>> from janome.tokenizer import Tokenizer
>>> from janome.analyzer import Analyzer
>>> from janome.tokenfilter import *
>>> text = u'すもももももももものうち'
>>> token_filters = [POSKeepFilter('名詞'), TokenCountFilter()]
>>> a = Analyzer(token_filters=token_filters)
>>> for k, v in a.analyze(text):
...   print('%s: %d' % (k, v))
... 
もも: 2
すもも: 1
うち: 1
```