### PR TITLE
Feature/dic with zipimport

### DIFF
--- a/examples/usage_with_zipimport.py
+++ b/examples/usage_with_zipimport.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""zipアーカイブから直接ロードする方法
+
+準備: wheelを作る(手動でパッケージをzip圧縮してもいい)
+$ pip wheel . --no-deps --no-binary
+もしくは、
+$ python setup.py bdist_wheel --universal
+出来上がった.whlファイルを使う
+
+How to import the zip archive
+
+You first build a wheel via `pip` command or `setup.py bdist_wheel`:
+$ pip wheel . --no-deps --no-binary
+$ python setup.py bdist_wheel --universal
+
+You can also create a zip archived package by yourself.
+"""
+
+import sys
+import glob
+
+ARCHIVE_NAME = 'Janome-*.whl'
+
+archive_path = glob.glob(ARCHIVE_NAME)[0]
+
+# avoiding conflict to existing package
+sys.path.insert(0, archive_path)
+
+from janome.tokenizer import Tokenizer
+t = Tokenizer()
+for token in t.tokenize(u'すもももももももものうち'):
+  print(token)
+
+import janome.tokenizer
+print(janome.tokenizer.__file__)
+# => Like './Janome-xxx.whl/janome/tokenizer.py'
+

--- a/janome/dic.py
+++ b/janome/dic.py
@@ -70,6 +70,7 @@ def load_all_fstdata():
     except OSError:
         return load_all_fstdata_from_package()
 
+
 def load_all_fstdata_from_package():
     fstdata = []
     for suffix in itertools.count():

--- a/janome/dic.py
+++ b/janome/dic.py
@@ -67,14 +67,13 @@ def load_all_fstdata():
     try:
         return [_load(os.path.join(SYSDIC_DIR, data_file))
                 for data_file in os.listdir(SYSDIC_DIR) if data_file.startswith(FILE_FST_DATA)]
-    except NotADirectoryError:
+    except OSError:
         return load_all_fstdata_from_package()
 
 def load_all_fstdata_from_package():
     fstdata = []
     for suffix in itertools.count():
         data = _load_package_data('sysdic', '{0}.{1}'.format(FILE_FST_DATA, suffix))
-        # data = _load('sysdic', '{0}.{1}'.format(FILE_FST_DATA, suffix))
         if data is None:
             break
         fstdata.append(data)
@@ -140,7 +139,7 @@ def _load(file):
 def _load_package_data(package, resource):
     try:
         rawdata = pkgutil.get_data(package, resource)
-    except OSError:
+    except IOError:
         return None
     return zlib.decompress(rawdata, zlib.MAX_WBITS | 16)
 

--- a/janome/dic.py
+++ b/janome/dic.py
@@ -67,7 +67,7 @@ def load_all_fstdata():
     try:
         return [_load(os.path.join(SYSDIC_DIR, data_file))
                 for data_file in os.listdir(SYSDIC_DIR) if data_file.startswith(FILE_FST_DATA)]
-    except OSError:
+    except NotADirectoryError:
         return load_all_fstdata_from_package()
 
 def load_all_fstdata_from_package():

--- a/janome/dic.py
+++ b/janome/dic.py
@@ -25,6 +25,11 @@ import traceback
 import logging
 import sys
 import re
+import itertools
+import pkgutil
+import zlib
+
+
 try:
     from functools import lru_cache
 except ImportError:
@@ -59,8 +64,21 @@ def save_fstdata(data, dir, suffix=''):
 
 
 def load_all_fstdata():
-    return [_load(os.path.join(SYSDIC_DIR, data_file))
-            for data_file in os.listdir(SYSDIC_DIR) if data_file.startswith(FILE_FST_DATA)]
+    try:
+        return [_load(os.path.join(SYSDIC_DIR, data_file))
+                for data_file in os.listdir(SYSDIC_DIR) if data_file.startswith(FILE_FST_DATA)]
+    except OSError:
+        return load_all_fstdata_from_package()
+
+def load_all_fstdata_from_package():
+    fstdata = []
+    for suffix in itertools.count():
+        data = _load_package_data('sysdic', '{0}.{1}'.format(FILE_FST_DATA, suffix))
+        # data = _load('sysdic', '{0}.{1}'.format(FILE_FST_DATA, suffix))
+        if data is None:
+            break
+        fstdata.append(data)
+    return fstdata
 
 
 def start_save_entries(dir, bucket_num):
@@ -118,6 +136,13 @@ def _load(file):
         data = f.read()
         return data
 
+
+def _load_package_data(package, resource):
+    try:
+        rawdata = pkgutil.get_data(package, resource)
+    except OSError:
+        return None
+    return zlib.decompress(rawdata, zlib.MAX_WBITS | 16)
 
 def _save_as_module(file, data):
     if not data:
@@ -179,7 +204,7 @@ def _save_entry_as_module_extra(file, morph_id, entry):
                 entry[9].encode('unicode_escape').decode('ascii') if PY3 else entry[9].encode('unicode_escape'))
             f.write(s)
             f.write('),')
-            
+
 
 class Dictionary(object):
     u"""
@@ -301,7 +326,7 @@ class MMapDictionary(object):
                 mm.close()
         for fp in self.open_files:
             fp.close()
-    
+
 
 class UnknownsDictionary(object):
     def __init__(self, chardefs, unknowns):

--- a/tests/test_dic.py
+++ b/tests/test_dic.py
@@ -22,11 +22,11 @@ PY3 = sys.version_info[0] == 3
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parent_dir)
 
+import janome.dic
 from janome.dic import *
 from sysdic import entries, mmap_entries, connections, chardef, unknowns
 
 import unittest
-import unittest.mock
 
 
 class TestDictionary(unittest.TestCase):
@@ -148,9 +148,16 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(2, len(sys_dic.lookup(u'叩く'.encode('utf8'))))
 
     def test_load_all_fst_data_from_package(self):
-        with unittest.mock.patch('janome.dic.load_all_fstdata', new=load_all_fstdata_from_package):
+        # Py2.7 doesn't have unittest.mock, so manually replaced the method
+        store = janome.dic.load_all_fstdata
+        janome.dic.load_all_fstdata = janome.dic.load_all_fstdata_from_package
+        try:
             sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
             self.assertEqual(11, len(sys_dic.lookup(u'小書き'.encode('utf8'))))
+        except Exception:
+            janome.dic.load_all_fstdata = store
+            raise
+
 
     def test_user_dictionary(self):
         # create user dictionary from csv

--- a/tests/test_dic.py
+++ b/tests/test_dic.py
@@ -26,6 +26,7 @@ from janome.dic import *
 from sysdic import entries, mmap_entries, connections, chardef, unknowns
 
 import unittest
+import unittest.mock
 
 
 class TestDictionary(unittest.TestCase):
@@ -145,7 +146,12 @@ class TestDictionary(unittest.TestCase):
 
         self.assertEqual(2, len(sys_dic.lookup(u'叩く'.encode('utf8'))))
         self.assertEqual(2, len(sys_dic.lookup(u'叩く'.encode('utf8'))))
-        
+
+    def test_load_all_fst_data_from_package(self):
+        with unittest.mock.patch('janome.dic.load_all_fstdata', new=load_all_fstdata_from_package):
+            sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
+            self.assertEqual(11, len(sys_dic.lookup(u'小書き'.encode('utf8'))))
+
     def test_user_dictionary(self):
         # create user dictionary from csv
         user_dic = UserDictionary(user_dict=os.path.join(parent_dir, 'tests/user_ipadic.csv'),


### PR DESCRIPTION
## 問題点

* 現状のFSTバイナリの読み込み方がパッケージ下のファイル読み込みになっている
* zipimportしたい案件で失敗する(パッケージをzipで固めてimportする方法)

例: 

```
import sys
sys.path.append('janome.zip')
from janome.tokenizer import Tokenizer
t = Tokenizer()  # ここで死ぬ
```

## 解決案

* 標準のpkgutil.get_data()を用いて、パッケージからバイナリを読み出す
* パフォーマンスへの影響がわからないため、失敗したときのみpkgutilを使う方式にフォールバックするようにする

宜しくおねがいします🙏