### PR TITLE
Refactoring: Use keyword-only arguments (PEP 3102) for public APIs

### DIFF
--- a/examples/usage_analyzer.py
+++ b/examples/usage_analyzer.py
@@ -11,7 +11,7 @@ text = '蛇の目はPure Ｐｙｔｈｏｎな形態素解析器です。'
 char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter('蛇の目', 'janome')]
 tokenizer = Tokenizer()
 token_filters = [CompoundNounFilter(), LowerCaseFilter()]
-a = Analyzer(char_filters, tokenizer, token_filters)
+a = Analyzer(char_filters=char_filters, tokenizer=tokenizer, token_filters=token_filters)
 for token in a.analyze(text):
     print(token)
 

--- a/janome/analyzer.py
+++ b/janome/analyzer.py
@@ -57,7 +57,7 @@ Usage (word count with TokenCountFilter):
 うち: 1
 """
 
-from typing import List, Iterator, Any
+from typing import List, Iterator, Any, Optional
 from .tokenizer import Tokenizer
 from .charfilter import CharFilter
 from .tokenfilter import TokenFilter
@@ -71,7 +71,9 @@ class Analyzer(object):
     Added in *version 0.3.4*
     """
 
-    def __init__(self, char_filters: List[CharFilter] = [], tokenizer: Tokenizer = None,
+    def __init__(self, *,
+                 char_filters: List[CharFilter] = [],
+                 tokenizer: Optional[Tokenizer] = None,
                  token_filters: List[TokenFilter] = []):
         """
         Initialize Analyzer object with CharFilters, a Tokenizer and TokenFilters.

--- a/janome/tokenizer.py
+++ b/janome/tokenizer.py
@@ -140,7 +140,7 @@ class Tokenizer(object):
     MAX_CHUNK_SIZE = 1024
     CHUNK_SIZE = 500
 
-    def __init__(self, udic: str = '',
+    def __init__(self, udic: str = '', *,
                  udic_enc: str = 'utf8',
                  udic_type: str = 'ipadic',
                  max_unknown_length: int = 1024,
@@ -182,7 +182,7 @@ class Tokenizer(object):
             self.user_dic = None
         self.max_unknown_length = max_unknown_length
 
-    def tokenize(self, text: str, wakati: bool = False, baseform_unk: bool = True, dotfile: str = '') \
+    def tokenize(self, text: str, *, wakati: bool = False, baseform_unk: bool = True, dotfile: str = '') \
             -> Iterator[Union[Token, str]]:
         """
         Tokenize the input text.

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -37,10 +37,10 @@ class TestAnalyzer(unittest.TestCase):
         self.assertTrue(len(a.token_filters) == 0)
 
     def test_analyzer_custom(self):
-        char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter(u'\s+', u'')]
+        char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter('\s+', '')]
         tokenizer = Tokenizer(mmap=True)
-        token_filters = [CompoundNounFilter(), POSStopFilter([u'記号', u'助詞']), LowerCaseFilter()]
-        a = Analyzer(char_filters, tokenizer, token_filters)
+        token_filters = [CompoundNounFilter(), POSStopFilter(['記号', '助詞']), LowerCaseFilter()]
+        a = Analyzer(char_filters=char_filters, tokenizer=tokenizer, token_filters=token_filters)
         self.assertTrue(len(a.char_filters) == 2)
         self.assertIsInstance(a.char_filters[0], UnicodeNormalizeCharFilter)
         self.assertIsInstance(a.char_filters[1], RegexReplaceCharFilter)
@@ -51,13 +51,13 @@ class TestAnalyzer(unittest.TestCase):
         self.assertIsInstance(a.token_filters[2], LowerCaseFilter)
 
     def test_analyze(self):
-        char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter(u'蛇の目', u'janome')]
+        char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter('蛇の目', 'janome')]
         tokenizer = Tokenizer()
-        token_filters = [CompoundNounFilter(), POSStopFilter([u'記号', u'助詞']), LowerCaseFilter(),
+        token_filters = [CompoundNounFilter(), POSStopFilter(['記号', '助詞']), LowerCaseFilter(),
                          ExtractAttributeFilter('surface')]
-        a = Analyzer(char_filters, tokenizer, token_filters)
-        tokens = a.analyze(u'蛇の目はPure Ｐｙｔｈｏｎな形態素解析器です。')
-        self.assertEqual([u'janome', u'pure', u'python', u'な', u'形態素解析器', u'です'], list(tokens))
+        a = Analyzer(char_filters=char_filters, tokenizer=tokenizer, token_filters=token_filters)
+        tokens = a.analyze('蛇の目はPure Ｐｙｔｈｏｎな形態素解析器です。')
+        self.assertEqual(['janome', 'pure', 'python', 'な', '形態素解析器', 'です'], list(tokens))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For public APIs that takes a number of arguments, it would be desirable for safety that arguments are explicitly specified by name, not implicitly filled by their positions.

Related issue: #73 

