### PR TITLE
Refactoring: Use f-string instead of '%' notation

### DIFF
--- a/janome/dic.py
+++ b/janome/dic.py
@@ -223,8 +223,8 @@ class RAMDictionary(Dictionary):
             return res
         except Exception:
             logger.error('Cannot load dictionary data. The dictionary may be corrupted?')
-            logger.error('input=%s' % s)
-            logger.error('outputs=%s' % str(outputs))
+            logger.error(f'input={s}')
+            logger.error(f'outputs={str(outputs)}')
             traceback.format_exc()
             sys.exit(1)
 
@@ -277,8 +277,8 @@ class MMapDictionary(Dictionary):
             return matched_entries
         except Exception:
             logger.error('Cannot load dictionary data. The dictionary may be corrupted?')
-            logger.error('input=%s' % s)
-            logger.error('outputs=%s' % str(outputs))
+            logger.error(f'input={s}')
+            logger.error(f'outputs={str(outputs)}')
             traceback.format_exc()
             sys.exit(1)
 
@@ -306,7 +306,7 @@ class MMapDictionary(Dictionary):
             )
         except Exception:
             logger.error('Cannot load extra info. The dictionary may be corrupted?')
-            logger.error('idx=%d' % idx)
+            logger.error(f'idx={idx}')
             traceback.format_exc()
             sys.exit(1)
 
@@ -429,10 +429,10 @@ class UserDictionary(RAMDictionary):
             for line in f:
                 line = line.rstrip()
                 surface, pos_major, reading = line.split(',')
-                part_of_speech = ','.join([pos_major, u'*', u'*', u'*'])
+                part_of_speech = ','.join([pos_major, '*', '*', '*'])
                 morph_id = len(surfaces)
                 surfaces.append((surface.encode('utf8'), pack('I', morph_id)))
-                entries[morph_id] = (surface, 0, 0, -100000, part_of_speech, u'*', u'*', surface, reading, reading)
+                entries[morph_id] = (surface, 0, 0, -100000, part_of_speech, '*', '*', surface, reading, reading)
         inputs = sorted(surfaces)  # inputs must be sorted.
         assert len(surfaces) == len(entries)
         processed, fst = create_minimum_transducer(inputs)
@@ -447,7 +447,7 @@ class UserDictionary(RAMDictionary):
         :compressionlevel: (Optional) gzip compression level. default is 9
         """
         if os.path.exists(to_dir) and not os.path.isdir(to_dir):
-            raise Exception('Not a directory : %s' % to_dir)
+            raise Exception(f'Not a directory : {to_dir}')
         elif not os.path.exists(to_dir):
             os.makedirs(to_dir, mode=int('0755', 8))
         _save(os.path.join(to_dir, FILE_USER_FST_DATA), self.compiledFST[0], compressionlevel)
@@ -465,7 +465,7 @@ class CompiledUserDictionary(RAMDictionary):
 
     def load_dict(self, dic_dir):
         if not os.path.exists(dic_dir) or not os.path.isdir(dic_dir):
-            raise Exception('No such directory : ' % dic_dir)
+            raise Exception(f'No such directory : {dic_dir}')
         data = _load(os.path.join(dic_dir, FILE_USER_FST_DATA))
         entries = pickle.loads(_load(os.path.join(dic_dir, FILE_USER_ENTRIES_DATA)))
         return data, entries

--- a/janome/fst.py
+++ b/janome/fst.py
@@ -253,7 +253,7 @@ def create_minimum_transducer(inputs):
         buffer[i - 1].set_transition(prev_word[i - 1], find_minimized(buffer[i]))
     find_minimized(buffer[0])
 
-    logger.debug('num of state: %d' % fstDict.size())
+    logger.debug(f'num of state: {fstDict.size()}')
     return (processed, fstDict)
 
 
@@ -316,7 +316,7 @@ def compileFST(fst):
             pos += len(bary)
         address[s.id] = pos
 
-    logger.debug('compiled arcs size: %d' % len(arcs))
+    logger.debug(f'compiled arcs size: {len(arcs)}')
     arcs.reverse()
     return b''.join(arcs)
 

--- a/janome/lattice.py
+++ b/janome/lattice.py
@@ -54,10 +54,9 @@ class Node(NodeBase):
         self.node_type = node_type
 
     def __str__(self):
-        return "(%s,%s,%s,%d,%s,%s,%s,%s,%s,%s) [back_pos=%d,back_index=%d]" % \
-               (self.surface, self.left_id, self.right_id, self.cost, self.part_of_speech,
-                self.infl_type, self.infl_form, self.base_form, self.reading, self.phonetic,
-                self.back_pos, self.back_index)
+        return f"({self.surface}, {self.left_id}, {self.right_id}, {self.cost}, {self.part_of_speech}, \
+                  {self.infl_type}, {self.infl_form}, {self.base_form}, {self.reading}, {self.phonetic}) \
+                      [back_pos = {self.back_pos}, back_index = {self.back_index}]"
 
     def node_label(self):
         return self.surface
@@ -107,7 +106,7 @@ class EOS(NodeBase):
         self.left_id = 0
 
     def __str__(self):
-        return '__EOS__' + ' [back_pos=%d]' % self.back_pos
+        return f'__EOS__ [back_pos={self.back_pos}]'
 
     def node_label(self):
         return 'EOS'
@@ -198,23 +197,22 @@ class Lattice(object):
             for node_id in node_ids:
                 (pos, idx) = node_id
                 node = self.snodes[pos][idx]
-                id_str = '%d.%d' % (pos, idx)
-                label = '%s\\n%s' % (node.node_label(), str(node.cost))
+                id_str = f'{pos}.{idx}'
+                label = f'{node.node_label()}\\n{str(node.cost)}'
                 shape = 'ellipse' if isinstance(node, BOS) or isinstance(node, EOS) else 'box'
                 color = 'lightblue' if isinstance(node, BOS) or isinstance(node, EOS) or node in path else 'lightgray'
                 font = 'MS UI Gothic' if os.name == 'nt' else ''
-                f.write('  %s [label="%s",shape=%s,style=filled,fillcolor=%s,fontname="%s"];\n' %
-                        (id_str, label, shape, color, font))
+                f.write(
+                    f'  {id_str} [label="{label}",shape={shape},style=filled,fillcolor={color},fontname="{font}"];\n')
             for edge in edges:
                 ((pos1, idx1), (pos2, idx2)) = edge
                 node1 = self.snodes[pos1][idx1]
                 node2 = self.snodes[pos2][idx2]
-                id_str1 = '%d.%d' % (pos1, idx1)
-                id_str2 = '%d.%d' % (pos2, idx2)
+                id_str1 = f'{pos1}.{idx1}'
+                id_str2 = f'{pos2}.{idx2}'
                 label = str(self.dic.get_trans_cost(node1.right_id, node2.left_id))
                 (color, style) = ('blue', 'bold') if node1 in path and node2 in path else ('black', 'solid')
-                f.write('  %s -> %s [label="%s",color=%s,style=%s,fontcolor=red];\n' %
-                        (id_str1, id_str2, label, color, style))
+                f.write(f'  {id_str1} -> {id_str2} [label="{label}",color={color},style={style},fontcolor=red];\n')
             f.write('}\n')
 
     def __open_file(self, filename, mode, encoding):

--- a/janome/tokenfilter.py
+++ b/janome/tokenfilter.py
@@ -131,9 +131,9 @@ class CompoundNounFilter(TokenFilter):
         _ret = None
         for token in tokens:
             if _ret:
-                if token.part_of_speech.startswith(u'名詞') and _ret.part_of_speech.startswith(u'名詞'):
+                if token.part_of_speech.startswith('名詞') and _ret.part_of_speech.startswith('名詞'):
                     _ret.surface += token.surface
-                    _ret.part_of_speech = u'名詞,複合,*,*'
+                    _ret.part_of_speech = '名詞,複合,*,*'
                     _ret.base_form += token.base_form
                     _ret.reading += token.reading
                     _ret.phonetic += token.phonetic
@@ -164,7 +164,7 @@ class ExtractAttributeFilter(TokenFilter):
                     'part_of_speech', 'infl_type', 'infl_form', 'base_form', 'reading' and 'phonetic'.
         """
         if att not in ['surface', 'part_of_speech', 'infl_type', 'infl_form', 'base_form', 'reading', 'phonetic']:
-            raise Exception('Unknown attribute name: %s' % att)
+            raise Exception(f'Unknown attribute name: {att}')
         self.att = att
 
     def apply(self, tokens: Iterator[Token]) -> Iterator[str]:
@@ -194,7 +194,7 @@ class TokenCountFilter(TokenFilter):
         :param sorted: sort items by term frequency
         """
         if att not in ['surface', 'part_of_speech', 'infl_type', 'infl_form', 'base_form', 'reading', 'phonetic']:
-            raise Exception('Unknown attribute name: %s' % att)
+            raise Exception(f'Unknown attribute name: {att}')
         self.att = att
         self.sorted = sorted
 

--- a/janome/tokenizer.py
+++ b/janome/tokenizer.py
@@ -127,9 +127,8 @@ class Token(object):
         self.node_type = node.node_type
 
     def __str__(self):
-        return '%s\t%s,%s,%s,%s,%s,%s' % \
-            (self.surface, self.part_of_speech, self.infl_type, self.infl_form, self.base_form,
-                self.reading, self.phonetic)
+        return f'{self.surface}\t' \
+            f'{self.part_of_speech},{self.infl_type},{self.infl_form},{self.base_form},{self.reading},{self.phonetic}'
 
 
 class Tokenizer(object):


### PR DESCRIPTION
Use f-string for cleaner formatting.

Related issue: #73 