### PR TITLE
Fix Analyzer usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Run
   >>> char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter(u'蛇の目', u'janome')]
   >>> tokenizer = Tokenizer()
   >>> token_filters = [CompoundNounFilter(), POSStopFilter(['記号','助詞']), LowerCaseFilter()]
-  >>> a = Analyzer(char_filters, tokenizer, token_filters)
+  >>> a = Analyzer(char_filters=char_filters, tokenizer=tokenizer, token_filters=token_filters)
   >>> for token in a.analyze(text):
   ...     print(token)
   ...

--- a/janome/analyzer.py
+++ b/janome/analyzer.py
@@ -30,7 +30,7 @@ Usage:
 >>> char_filters = [UnicodeNormalizeCharFilter(), RegexReplaceCharFilter(u'蛇の目', u'janome')]
 >>> tokenizer = Tokenizer()
 >>> token_filters = [CompoundNounFilter(), POSStopFilter(['記号','助詞']), LowerCaseFilter()]
->>> a = Analyzer(char_filters, tokenizer, token_filters)
+>>> a = Analyzer(char_filters=char_filters, tokenizer=tokenizer, token_filters=token_filters)
 >>> for token in a.analyze(text):
 ...     print(token)
 ...


### PR DESCRIPTION
From https://github.com/mocobeta/janome/pull/77/, interface of `Analyzer` was changed(keyword-only arguments). But some usage is still old interface.

- https://github.com/mocobeta/janome/blob/master/janome/analyzer.py#L74-L77