### PR TITLE
ipadic/__init__.py.tmpl: insert root_dir at sys.path for import janome.dic

### DIFF
--- a/ipadic/__init__.py.tmpl
+++ b/ipadic/__init__.py.tmpl
@@ -1,7 +1,8 @@
 # type: ignore
 import os, sys
 base_dir = os.path.dirname(os.path.abspath(__file__))
-
+root_dir = os.path.dirname(os.path.dirname(base_dir))
+sys.path.insert(0, root_dir)
 from janome.dic import LoadingDictionaryError
 from . import connections1, connections2
 from . import chardef, unknowns


### PR DESCRIPTION
`validate.sh` is using `validate.py`. `validate.py` import  modules from `sysdic`.
`sysdic`/`__init__.py` file is auto-generated by `build.sh`.
This generates by copy `ipadic/__init__.py.tmpl` to `sysdic`.
But `__init__.py.tmpl` has problem by path for import `janome.dic` module. So occurred errors.
I fixed that.