### PR TITLE
Fix Non-Deterministic Behavior of Tokenizer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+* 0.4.2 (yyyy.mm.dd)
+  - #105: Fix Non-deterministic behavior of tokenizer (thanks @sueki1242)
+
 * 0.4.1 (2020.9.21)
   - #87: Add progress indicator when compiling user dictionary (thanks @uezo)
   - #88: Remove --mmap option from CLI tool

--- a/janome/lattice.py
+++ b/janome/lattice.py
@@ -139,6 +139,10 @@ class Lattice(object):
             cost = enode.min_cost + dic.get_trans_cost(enode.right_id, node_left_id)
             if cost < min_cost:
                 min_cost, best_node = cost, enode
+            elif cost == min_cost \
+                    and isinstance(best_node, SurfaceNode) and isinstance(enode, SurfaceNode) \
+                    and enode.num < best_node.num:
+                min_cost, best_node = cost, enode
         node.min_cost = min_cost + node.cost
         node.back_index = best_node.index
         node.back_pos = best_node.pos


### PR DESCRIPTION
The behavior of this tokenizer is sometimes non-deterministic.

```
$ janome
えびの上江
えび    名詞,一般,*,*,*,*,えび,エビ,エビ
の      助詞,連体化,*,*,*,*,の,ノ,ノ
上江    名詞,固有名詞,地域,一般,*,*,上江,カミエ,カミエ
^Z
$ janome
えびの上江
えび    名詞,一般,*,*,*,*,えび,エビ,エビ
の      助詞,連体化,*,*,*,*,の,ノ,ノ
上江    名詞,固有名詞,地域,一般,*,*,上江,ウワエ,ウワエ
```

In `Lattice.add()`, best_node is selected whose cost is minimum.
If multiple nodes have the same mimimum cost, those visited first will be the best_node.
The visiting order of nodes is non-deterministic because it indirectly depends on set iteration order
(`Matcher.run()` returns a set object and `Dictionary.lookup()` iterates it).

This PR intends to omit such randomness by adding a tie-breaking factor ( `SurfaceNode.num` ) for best_node selection.

I'm afraid to say that I don't fully understand the dictionary structure and have 100% confidence that `SurfaceNode.num` is proper for this purpose, so I'm sorry in advance if I do something strange.