### PR TITLE
Make system dictionary singleton

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,6 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Test
       run: |
+        pip install psutil
         python setup.py test
 
   check:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Unit tests for coverage
       run: |
         pip install coverage
+        pip install psutil
         python setup.py develop
         coverage run -m unittest discover tests
     - name: Coveralls

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 * 0.4.2 (yyyy.mm.dd)
   - #105: Fix Non-deterministic behavior of tokenizer (thanks @sueki1242)
+  - #107: Make system dictionary singleton to avoid 'Too much open files' error.
 
 * 0.4.1 (2020.9.21)
   - #87: Add progress indicator when compiling user dictionary (thanks @uezo)

--- a/janome/dic.py
+++ b/janome/dic.py
@@ -367,26 +367,6 @@ class UnknownsDictionary(object):
         return -1
 
 
-class SystemDictionary(RAMDictionary, UnknownsDictionary):
-    """
-    System dictionary class
-    """
-
-    def __init__(self, entries, connections, chardefs, unknowns):
-        RAMDictionary.__init__(self, entries, connections)
-        UnknownsDictionary.__init__(self, chardefs, unknowns)
-
-
-class MMapSystemDictionary(MMapDictionary, UnknownsDictionary):
-    """
-    MMap System dictionary class
-    """
-
-    def __init__(self, mmap_entries, connections, chardefs, unknowns):
-        MMapDictionary.__init__(self, mmap_entries[0], mmap_entries[1], mmap_entries[2], connections)
-        UnknownsDictionary.__init__(self, chardefs, unknowns)
-
-
 class UserDictionary(RAMDictionary):
     """
     User dictionary class (on-the-fly)

--- a/janome/system_dic.py
+++ b/janome/system_dic.py
@@ -1,0 +1,59 @@
+# Copyright 2022 moco_beta
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+
+from .sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns
+from .dic import RAMDictionary, MMapDictionary, UnknownsDictionary
+
+class SystemDictionary(RAMDictionary, UnknownsDictionary):
+    """
+    System dictionary class
+    """
+
+    __INSTANCE = None
+    __lock = threading.Lock()
+
+    @classmethod
+    def instance(cls):
+        if not cls.__INSTANCE:
+            with cls.__lock:
+                if not cls.__INSTANCE:
+                   cls.__INSTANCE = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
+        return cls.__INSTANCE
+
+    def __init__(self, entries, connections, chardefs, unknowns):
+        RAMDictionary.__init__(self, entries, connections)
+        UnknownsDictionary.__init__(self, chardefs, unknowns)
+
+
+class MMapSystemDictionary(MMapDictionary, UnknownsDictionary):
+    """
+    MMap System dictionary class
+    """
+
+    __INSTANCE = None
+    __lock = threading.Lock()
+
+    @classmethod
+    def instance(cls):
+        if not cls.__INSTANCE:
+            with cls.__lock:
+                if not cls.__INSTANCE:
+                    cls.__INSTANCE = MMapSystemDictionary(mmap_entries(), connections, chardef.DATA, unknowns.DATA)
+        return cls.__INSTANCE
+
+    def __init__(self, mmap_entries, connections, chardefs, unknowns):
+        MMapDictionary.__init__(self, mmap_entries[0], mmap_entries[1], mmap_entries[2], connections)
+        UnknownsDictionary.__init__(self, chardefs, unknowns)

--- a/janome/system_dic.py
+++ b/janome/system_dic.py
@@ -14,8 +14,9 @@
 
 import threading
 
-from .sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns
+from .sysdic import entries, mmap_entries, connections, chardef, unknowns
 from .dic import RAMDictionary, MMapDictionary, UnknownsDictionary
+
 
 class SystemDictionary(RAMDictionary, UnknownsDictionary):
     """
@@ -30,7 +31,7 @@ class SystemDictionary(RAMDictionary, UnknownsDictionary):
         if not cls.__INSTANCE:
             with cls.__lock:
                 if not cls.__INSTANCE:
-                   cls.__INSTANCE = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
+                    cls.__INSTANCE = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
         return cls.__INSTANCE
 
     def __init__(self, entries, connections, chardefs, unknowns):

--- a/janome/system_dic.py
+++ b/janome/system_dic.py
@@ -14,7 +14,7 @@
 
 import threading
 
-from .sysdic import entries, mmap_entries, connections, chardef, unknowns
+from .sysdic import entries, mmap_entries, connections, chardef, unknowns  # type: ignore
 from .dic import RAMDictionary, MMapDictionary, UnknownsDictionary
 
 

--- a/janome/tokenizer.py
+++ b/janome/tokenizer.py
@@ -94,6 +94,7 @@ import os
 from typing import Iterator, Union, Tuple, Optional, Any
 from .lattice import Lattice, Node, SurfaceNode, BOS, EOS, NodeType  # type: ignore
 from .dic import SystemDictionary, MMapSystemDictionary, UserDictionary, CompiledUserDictionary  # type: ignore
+from .fst import Matcher
 
 try:
     from janome.sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns  # type: ignore
@@ -177,11 +178,12 @@ class Tokenizer(object):
         self.sys_dic: Union[SystemDictionary, MMapSystemDictionary]
         self.user_dic: Optional[Union[UserDictionary, CompiledUserDictionary]]
         self.wakati = wakati
+        self.matcher = Matcher(all_fstdata())
         if mmap:
-            self.sys_dic = MMapSystemDictionary(all_fstdata(), mmap_entries(wakati),
+            self.sys_dic = MMapSystemDictionary(mmap_entries(wakati),
                                                 connections, chardef.DATA, unknowns.DATA)
         else:
-            self.sys_dic = SystemDictionary(all_fstdata(), entries(wakati), connections,
+            self.sys_dic = SystemDictionary(entries(wakati), connections,
                                             chardef.DATA, unknowns.DATA)
         if udic:
             if udic.endswith('.csv'):
@@ -244,7 +246,7 @@ class Tokenizer(object):
                 matched = len(entries) > 0
 
             # system dictionary
-            entries = self.sys_dic.lookup(encoded_partial_text)
+            entries = self.sys_dic.lookup(encoded_partial_text, self.matcher)
             for e in entries:
                 lattice.add(SurfaceNode(e, NodeType.SYS_DICT))
             matched = len(entries) > 0

--- a/janome/tokenizer.py
+++ b/janome/tokenizer.py
@@ -98,12 +98,12 @@ from .system_dic import SystemDictionary, MMapSystemDictionary
 from .fst import Matcher
 
 try:
-    from janome.sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns  # type: ignore
+    from janome.sysdic import all_fstdata, connections  # type: ignore
 except ImportError:
     # hack for unit testing...
     parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path.insert(0, parent_dir)
-    from sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns  # type: ignore
+    from sysdic import all_fstdata, connections  # type: ignore
 
 
 DEFAULT_MMAP_MODE = sys.maxsize > 2**32

--- a/janome/tokenizer.py
+++ b/janome/tokenizer.py
@@ -93,7 +93,8 @@ import sys
 import os
 from typing import Iterator, Union, Tuple, Optional, Any
 from .lattice import Lattice, Node, SurfaceNode, BOS, EOS, NodeType  # type: ignore
-from .dic import SystemDictionary, MMapSystemDictionary, UserDictionary, CompiledUserDictionary  # type: ignore
+from .dic import UserDictionary, CompiledUserDictionary  # type: ignore
+from .system_dic import SystemDictionary, MMapSystemDictionary
 from .fst import Matcher
 
 try:
@@ -180,11 +181,9 @@ class Tokenizer(object):
         self.wakati = wakati
         self.matcher = Matcher(all_fstdata())
         if mmap:
-            self.sys_dic = MMapSystemDictionary(mmap_entries(wakati),
-                                                connections, chardef.DATA, unknowns.DATA)
+            self.sys_dic = MMapSystemDictionary.instance()
         else:
-            self.sys_dic = SystemDictionary(entries(wakati), connections,
-                                            chardef.DATA, unknowns.DATA)
+            self.sys_dic = SystemDictionary.instance()
         if udic:
             if udic.endswith('.csv'):
                 # build user dictionary from CSV

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ typed-ast==1.4.1
 typing-extensions==3.7.4.2
 twine==3.2.0
 wheel==0.35.1
+psutil==5.9.0

--- a/tests/suite.py
+++ b/tests/suite.py
@@ -14,7 +14,8 @@
 
 import unittest
 from test_fst import TestFST
-from test_dic import TestDictionary
+from test_dic import TestUserDictionary
+from test_system_dic import TestSystemDictionary
 from test_lattice import TestLattice
 from test_tokenizer import TestTokenizer
 from test_charfilter import TestCharFilter
@@ -25,7 +26,8 @@ from test_analyzer import TestAnalyzer
 def suite():
     suite = unittest.TestSuite()
     suite.addTests(unittest.makeSuite(TestFST))
-    suite.addTests(unittest.makeSuite(TestDictionary))
+    suite.addTests(unittest.makeSuite(TestUserDictionary))
+    suite.addTests(unittest.makeSuite(TestSystemDictionary))
     suite.addTests(unittest.makeSuite(TestLattice))
     suite.addTests(unittest.makeSuite(TestTokenizer))
     suite.addTests(unittest.makeSuite(TestCharFilter))

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from janome.dic import MMapSystemDictionary
 from janome.tokenfilter import CompoundNounFilter, POSStopFilter, LowerCaseFilter, ExtractAttributeFilter
 from janome.charfilter import UnicodeNormalizeCharFilter, RegexReplaceCharFilter
 from janome.tokenizer import Tokenizer

--- a/tests/test_dic.py
+++ b/tests/test_dic.py
@@ -24,6 +24,7 @@ from janome.dic import (
     FILE_USER_FST_DATA,
     FILE_USER_ENTRIES_DATA
 )
+from janome.fst import Matcher
 from janome.progress import SimpleProgressIndicator, logger as p_logger
 
 # TODO: better way to find package...
@@ -33,8 +34,9 @@ sys.path.insert(0, parent_dir)
 
 class TestDictionary(unittest.TestCase):
     def test_system_dictionary_ipadic(self):
-        sys_dic = SystemDictionary(all_fstdata(), entries(), connections, chardef.DATA, unknowns.DATA)
-        self.assertEqual(7, len(sys_dic.lookup('形態素'.encode('utf-8'))))
+        matcher = Matcher(all_fstdata())
+        sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
+        self.assertEqual(7, len(sys_dic.lookup('形態素'.encode('utf-8'), matcher)))
         self.assertEqual(1, sys_dic.get_trans_cost(0, 1))
         self.assertEqual({'HIRAGANA': []}, sys_dic.get_char_categories('は'))
         self.assertEqual({'KATAKANA': []}, sys_dic.get_char_categories('ハ'))
@@ -58,9 +60,10 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(2, sys_dic.unknown_length('HIRAGANA'))
 
     def test_property_types(self):
-        sys_dic = SystemDictionary(all_fstdata(), entries(), connections, chardef.DATA, unknowns.DATA)
+        matcher = Matcher(all_fstdata())
+        sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
         # entry in the system dictionary
-        entry = sys_dic.lookup('すもも'.encode('utf8'))[0]
+        entry = sys_dic.lookup('すもも'.encode('utf8'), matcher)[0]
         self.assertTrue(type(entry[1]) is str)
         self.assertTrue(type(entry[0]) is int)
         self.assertTrue(type(entry[2]) is int)
@@ -83,8 +86,9 @@ class TestDictionary(unittest.TestCase):
         self.assertTrue(type(entry[2]) is int)
 
         # mmap dict etnry
-        mmap_dic = MMapSystemDictionary(all_fstdata(), mmap_entries(), connections, chardef.DATA, unknowns.DATA)
-        entry = mmap_dic.lookup(u'すもも'.encode('utf8'))[0]
+        matcher = Matcher(all_fstdata())
+        mmap_dic = MMapSystemDictionary(mmap_entries(), connections, chardef.DATA, unknowns.DATA)
+        entry = mmap_dic.lookup(u'すもも'.encode('utf8'), matcher)[0]
         self.assertTrue(type(entry[1]) is str)
         self.assertTrue(type(entry[0]) is int)
         self.assertTrue(type(entry[2]) is int)
@@ -110,16 +114,17 @@ class TestDictionary(unittest.TestCase):
         self.assertTrue(type(entry[4]) is int)
 
     def test_system_dictionary_cache(self):
-        sys_dic = SystemDictionary(all_fstdata(), entries(), connections, chardef.DATA, unknowns.DATA)
-        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'))))
-        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'))))
-        self.assertEqual(11, len(sys_dic.lookup('小書きにしました'.encode('utf8'))))
+        matcher = Matcher(all_fstdata())
+        sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
+        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'), matcher)))
+        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'), matcher)))
+        self.assertEqual(11, len(sys_dic.lookup('小書きにしました'.encode('utf8'), matcher)))
 
-        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'))))
-        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'))))
+        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'), matcher)))
+        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'), matcher)))
 
-        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'))))
-        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'))))
+        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'), matcher)))
+        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'), matcher)))
 
     def test_user_dictionary(self):
         # create user dictionary from csv

--- a/tests/test_dic.py
+++ b/tests/test_dic.py
@@ -15,10 +15,8 @@
 import os
 import sys
 import unittest
-from janome.sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns
+from janome.sysdic import connections
 from janome.dic import (
-    SystemDictionary,
-    MMapSystemDictionary,
     UserDictionary,
     CompiledUserDictionary,
     FILE_USER_FST_DATA,
@@ -32,78 +30,8 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parent_dir)
 
 
-class TestDictionary(unittest.TestCase):
-    def test_system_dictionary_ipadic(self):
-        matcher = Matcher(all_fstdata())
-        sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
-        self.assertEqual(7, len(sys_dic.lookup('形態素'.encode('utf-8'), matcher)))
-        self.assertEqual(1, sys_dic.get_trans_cost(0, 1))
-        self.assertEqual({'HIRAGANA': []}, sys_dic.get_char_categories('は'))
-        self.assertEqual({'KATAKANA': []}, sys_dic.get_char_categories('ハ'))
-        self.assertEqual({'KATAKANA': []}, sys_dic.get_char_categories('ﾊ'))
-        self.assertEqual({'KANJI': []}, sys_dic.get_char_categories('葉'))
-        self.assertEqual({'ALPHA': []}, sys_dic.get_char_categories('C'))
-        self.assertEqual({'ALPHA': []}, sys_dic.get_char_categories('Ｃ'))
-        self.assertEqual({'SYMBOL': []}, sys_dic.get_char_categories('#'))
-        self.assertEqual({'SYMBOL': []}, sys_dic.get_char_categories('＃'))
-        self.assertEqual({'NUMERIC': []}, sys_dic.get_char_categories('5'))
-        self.assertEqual({'NUMERIC': []}, sys_dic.get_char_categories('５'))
-        self.assertEqual({'KANJI': [], 'KANJINUMERIC': ['KANJI']}, sys_dic.get_char_categories('五'))
-        self.assertEqual({'GREEK': []}, sys_dic.get_char_categories('Γ'))
-        self.assertEqual({'CYRILLIC': []}, sys_dic.get_char_categories('Б'))
-        self.assertEqual({'DEFAULT': []}, sys_dic.get_char_categories('𠮷'))
-        self.assertEqual({'DEFAULT': []}, sys_dic.get_char_categories('한'))
-        self.assertTrue(sys_dic.unknown_invoked_always('ALPHA'))
-        self.assertFalse(sys_dic.unknown_invoked_always('KANJI'))
-        self.assertTrue(sys_dic.unknown_grouping('NUMERIC'))
-        self.assertFalse(sys_dic.unknown_grouping('KANJI'))
-        self.assertEqual(2, sys_dic.unknown_length('HIRAGANA'))
-
+class TestUserDictionary(unittest.TestCase):
     def test_property_types(self):
-        matcher = Matcher(all_fstdata())
-        sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
-        # entry in the system dictionary
-        entry = sys_dic.lookup('すもも'.encode('utf8'), matcher)[0]
-        self.assertTrue(type(entry[1]) is str)
-        self.assertTrue(type(entry[0]) is int)
-        self.assertTrue(type(entry[2]) is int)
-        self.assertTrue(type(entry[3]) is int)
-        self.assertTrue(type(entry[4]) is int)
-
-        entry_extra = sys_dic.lookup_extra(entry[0])
-        self.assertTrue(type(entry_extra[0]) is str)
-        self.assertTrue(type(entry_extra[1]) is str)
-        self.assertTrue(type(entry_extra[2]) is str)
-        self.assertTrue(type(entry_extra[3]) is str)
-        self.assertTrue(type(entry_extra[4]) is str)
-        self.assertTrue(type(entry_extra[5]) is str)
-
-        # unknown entry
-        entry = sys_dic.unknowns.get(u'HIRAGANA')[0]
-        self.assertTrue(type(entry[3]) is str)
-        self.assertTrue(type(entry[0]) is int)
-        self.assertTrue(type(entry[1]) is int)
-        self.assertTrue(type(entry[2]) is int)
-
-        # mmap dict etnry
-        matcher = Matcher(all_fstdata())
-        mmap_dic = MMapSystemDictionary(mmap_entries(), connections, chardef.DATA, unknowns.DATA)
-        entry = mmap_dic.lookup(u'すもも'.encode('utf8'), matcher)[0]
-        self.assertTrue(type(entry[1]) is str)
-        self.assertTrue(type(entry[0]) is int)
-        self.assertTrue(type(entry[2]) is int)
-        self.assertTrue(type(entry[3]) is int)
-        self.assertTrue(type(entry[4]) is int)
-
-        entry_extra = mmap_dic.lookup_extra(entry[0])
-        self.assertTrue(type(entry_extra[0]) is str)
-        self.assertTrue(type(entry_extra[1]) is str)
-        self.assertTrue(type(entry_extra[2]) is str)
-        self.assertTrue(type(entry_extra[3]) is str)
-        self.assertTrue(type(entry_extra[4]) is str)
-        self.assertTrue(type(entry_extra[5]) is str)
-
-        # entry in the user defined dictionary
         user_dic = UserDictionary(user_dict=os.path.join(parent_dir, 'tests/user_ipadic.csv'),
                                   enc='utf8', type='ipadic', connections=connections)
         entry = user_dic.lookup('東京スカイツリー'.encode('utf8'))[0]
@@ -112,19 +40,6 @@ class TestDictionary(unittest.TestCase):
         self.assertTrue(type(entry[2]) is int)
         self.assertTrue(type(entry[3]) is int)
         self.assertTrue(type(entry[4]) is int)
-
-    def test_system_dictionary_cache(self):
-        matcher = Matcher(all_fstdata())
-        sys_dic = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
-        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'), matcher)))
-        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'), matcher)))
-        self.assertEqual(11, len(sys_dic.lookup('小書きにしました'.encode('utf8'), matcher)))
-
-        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'), matcher)))
-        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'), matcher)))
-
-        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'), matcher)))
-        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'), matcher)))
 
     def test_user_dictionary(self):
         # create user dictionary from csv

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -16,7 +16,7 @@ import os
 import sys
 import unittest
 from janome.sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns
-from janome.dic import SystemDictionary, MMapSystemDictionary
+from janome.system_dic import SystemDictionary, MMapSystemDictionary
 from janome.fst import Matcher
 from janome.lattice import Lattice, BOS, EOS, SurfaceNode
 
@@ -26,8 +26,8 @@ sys.path.insert(0, parent_dir)
 
 
 MATCHER = Matcher(all_fstdata())
-SYS_DIC = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
-MMAP_SYS_DIC = MMapSystemDictionary(mmap_entries(), connections, chardef.DATA, unknowns.DATA)
+SYS_DIC = SystemDictionary.instance()
+MMAP_SYS_DIC = MMapSystemDictionary.instance()
 
 
 class TestLattice(unittest.TestCase):

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -17,6 +17,7 @@ import sys
 import unittest
 from janome.sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns
 from janome.dic import SystemDictionary, MMapSystemDictionary
+from janome.fst import Matcher
 from janome.lattice import Lattice, BOS, EOS, SurfaceNode
 
 # TODO: better way to find package...
@@ -24,8 +25,9 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, parent_dir)
 
 
-SYS_DIC = SystemDictionary(all_fstdata(), entries(), connections, chardef.DATA, unknowns.DATA)
-MMAP_SYS_DIC = MMapSystemDictionary(all_fstdata(), mmap_entries(), connections, chardef.DATA, unknowns.DATA)
+MATCHER = Matcher(all_fstdata())
+SYS_DIC = SystemDictionary(entries(), connections, chardef.DATA, unknowns.DATA)
+MMAP_SYS_DIC = MMapSystemDictionary(mmap_entries(), connections, chardef.DATA, unknowns.DATA)
 
 
 class TestLattice(unittest.TestCase):
@@ -39,7 +41,7 @@ class TestLattice(unittest.TestCase):
     def test_add_forward_end(self):
         s = 'すもも'
         lattice = Lattice(len(s), SYS_DIC)
-        entries = SYS_DIC.lookup(s.encode('utf8'))
+        entries = SYS_DIC.lookup(s.encode('utf8'), MATCHER)
         for entry in entries:
             lattice.add(SurfaceNode(entry))
         self.assertEqual(9, len(lattice.snodes[1]))
@@ -49,7 +51,7 @@ class TestLattice(unittest.TestCase):
 
         self.assertEqual(1, lattice.forward())
 
-        entries = SYS_DIC.lookup(s[1:].encode('utf8'))
+        entries = SYS_DIC.lookup(s[1:].encode('utf8'), MATCHER)
         for entry in entries:
             lattice.add(SurfaceNode(entry))
         self.assertEqual(4, len(lattice.snodes[2]))
@@ -58,7 +60,7 @@ class TestLattice(unittest.TestCase):
 
         self.assertEqual(1, lattice.forward())
 
-        entries = SYS_DIC.lookup(s[2:].encode('utf8'))
+        entries = SYS_DIC.lookup(s[2:].encode('utf8'), MATCHER)
         for entry in entries:
             lattice.add(SurfaceNode(entry))
         self.assertEqual(2, len(lattice.snodes[3]))
@@ -75,7 +77,7 @@ class TestLattice(unittest.TestCase):
         lattice = Lattice(len(s), SYS_DIC)
         pos = 0
         while pos < len(s):
-            entries = SYS_DIC.lookup(s[pos:].encode('utf8'))
+            entries = SYS_DIC.lookup(s[pos:].encode('utf8'), MATCHER)
             for e in entries:
                 lattice.add(SurfaceNode(e))
             pos += lattice.forward()
@@ -95,7 +97,7 @@ class TestLattice(unittest.TestCase):
     def test_add_forward_end_mmap(self):
         s = 'すもも'
         lattice = Lattice(len(s), SYS_DIC)
-        entries = MMAP_SYS_DIC.lookup(s.encode('utf8'))
+        entries = MMAP_SYS_DIC.lookup(s.encode('utf8'), MATCHER)
         for entry in entries:
             lattice.add(SurfaceNode(entry))
         self.assertEqual(9, len(lattice.snodes[1]))
@@ -105,7 +107,7 @@ class TestLattice(unittest.TestCase):
 
         self.assertEqual(1, lattice.forward())
 
-        entries = MMAP_SYS_DIC.lookup(s[1:].encode('utf8'))
+        entries = MMAP_SYS_DIC.lookup(s[1:].encode('utf8'), MATCHER)
         for entry in entries:
             lattice.add(SurfaceNode(entry))
         self.assertEqual(4, len(lattice.snodes[2]))
@@ -114,7 +116,7 @@ class TestLattice(unittest.TestCase):
 
         self.assertEqual(1, lattice.forward())
 
-        entries = MMAP_SYS_DIC.lookup(s[2:].encode('utf8'))
+        entries = MMAP_SYS_DIC.lookup(s[2:].encode('utf8'), MATCHER)
         for entry in entries:
             lattice.add(SurfaceNode(entry))
         self.assertEqual(2, len(lattice.snodes[3]))
@@ -131,7 +133,7 @@ class TestLattice(unittest.TestCase):
         lattice = Lattice(len(s), SYS_DIC)
         pos = 0
         while pos < len(s):
-            entries = MMAP_SYS_DIC.lookup(s[pos:].encode('utf8'))
+            entries = MMAP_SYS_DIC.lookup(s[pos:].encode('utf8'), MATCHER)
             for e in entries:
                 lattice.add(SurfaceNode(e))
             pos += lattice.forward()

--- a/tests/test_system_dic.py
+++ b/tests/test_system_dic.py
@@ -1,0 +1,135 @@
+# Copyright 2022 moco_beta
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from janome.sysdic import all_fstdata, entries, mmap_entries, connections, chardef, unknowns
+from janome.system_dic import SystemDictionary, MMapSystemDictionary
+from janome.fst import Matcher
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+
+
+class TestSystemDictionary(unittest.TestCase):
+
+    def test_dictionary_ipadic(self):
+        matcher = Matcher(all_fstdata())
+        sys_dic = SystemDictionary.instance()
+        self.assertEqual(7, len(sys_dic.lookup('形態素'.encode('utf-8'), matcher)))
+        self.assertEqual(1, sys_dic.get_trans_cost(0, 1))
+        self.assertEqual({'HIRAGANA': []}, sys_dic.get_char_categories('は'))
+        self.assertEqual({'KATAKANA': []}, sys_dic.get_char_categories('ハ'))
+        self.assertEqual({'KATAKANA': []}, sys_dic.get_char_categories('ﾊ'))
+        self.assertEqual({'KANJI': []}, sys_dic.get_char_categories('葉'))
+        self.assertEqual({'ALPHA': []}, sys_dic.get_char_categories('C'))
+        self.assertEqual({'ALPHA': []}, sys_dic.get_char_categories('Ｃ'))
+        self.assertEqual({'SYMBOL': []}, sys_dic.get_char_categories('#'))
+        self.assertEqual({'SYMBOL': []}, sys_dic.get_char_categories('＃'))
+        self.assertEqual({'NUMERIC': []}, sys_dic.get_char_categories('5'))
+        self.assertEqual({'NUMERIC': []}, sys_dic.get_char_categories('５'))
+        self.assertEqual({'KANJI': [], 'KANJINUMERIC': ['KANJI']}, sys_dic.get_char_categories('五'))
+        self.assertEqual({'GREEK': []}, sys_dic.get_char_categories('Γ'))
+        self.assertEqual({'CYRILLIC': []}, sys_dic.get_char_categories('Б'))
+        self.assertEqual({'DEFAULT': []}, sys_dic.get_char_categories('𠮷'))
+        self.assertEqual({'DEFAULT': []}, sys_dic.get_char_categories('한'))
+        self.assertTrue(sys_dic.unknown_invoked_always('ALPHA'))
+        self.assertFalse(sys_dic.unknown_invoked_always('KANJI'))
+        self.assertTrue(sys_dic.unknown_grouping('NUMERIC'))
+        self.assertFalse(sys_dic.unknown_grouping('KANJI'))
+        self.assertEqual(2, sys_dic.unknown_length('HIRAGANA'))
+
+    def test_mmap_dictionary_ipadic(self):
+        matcher = Matcher(all_fstdata())
+        sys_dic = MMapSystemDictionary.instance()
+        self.assertEqual(7, len(sys_dic.lookup('形態素'.encode('utf-8'), matcher)))
+        self.assertEqual(1, sys_dic.get_trans_cost(0, 1))
+        self.assertEqual({'HIRAGANA': []}, sys_dic.get_char_categories('は'))
+        self.assertEqual({'KATAKANA': []}, sys_dic.get_char_categories('ハ'))
+        self.assertEqual({'KATAKANA': []}, sys_dic.get_char_categories('ﾊ'))
+        self.assertEqual({'KANJI': []}, sys_dic.get_char_categories('葉'))
+        self.assertEqual({'ALPHA': []}, sys_dic.get_char_categories('C'))
+        self.assertEqual({'ALPHA': []}, sys_dic.get_char_categories('Ｃ'))
+        self.assertEqual({'SYMBOL': []}, sys_dic.get_char_categories('#'))
+        self.assertEqual({'SYMBOL': []}, sys_dic.get_char_categories('＃'))
+        self.assertEqual({'NUMERIC': []}, sys_dic.get_char_categories('5'))
+        self.assertEqual({'NUMERIC': []}, sys_dic.get_char_categories('５'))
+        self.assertEqual({'KANJI': [], 'KANJINUMERIC': ['KANJI']}, sys_dic.get_char_categories('五'))
+        self.assertEqual({'GREEK': []}, sys_dic.get_char_categories('Γ'))
+        self.assertEqual({'CYRILLIC': []}, sys_dic.get_char_categories('Б'))
+        self.assertEqual({'DEFAULT': []}, sys_dic.get_char_categories('𠮷'))
+        self.assertEqual({'DEFAULT': []}, sys_dic.get_char_categories('한'))
+        self.assertTrue(sys_dic.unknown_invoked_always('ALPHA'))
+        self.assertFalse(sys_dic.unknown_invoked_always('KANJI'))
+        self.assertTrue(sys_dic.unknown_grouping('NUMERIC'))
+        self.assertFalse(sys_dic.unknown_grouping('KANJI'))
+        self.assertEqual(2, sys_dic.unknown_length('HIRAGANA'))
+
+    def test_property_types(self):
+        matcher = Matcher(all_fstdata())
+        sys_dic = SystemDictionary.instance()
+        # entry in the system dictionary
+        entry = sys_dic.lookup('すもも'.encode('utf8'), matcher)[0]
+        self.assertTrue(type(entry[1]) is str)
+        self.assertTrue(type(entry[0]) is int)
+        self.assertTrue(type(entry[2]) is int)
+        self.assertTrue(type(entry[3]) is int)
+        self.assertTrue(type(entry[4]) is int)
+
+        entry_extra = sys_dic.lookup_extra(entry[0])
+        self.assertTrue(type(entry_extra[0]) is str)
+        self.assertTrue(type(entry_extra[1]) is str)
+        self.assertTrue(type(entry_extra[2]) is str)
+        self.assertTrue(type(entry_extra[3]) is str)
+        self.assertTrue(type(entry_extra[4]) is str)
+        self.assertTrue(type(entry_extra[5]) is str)
+
+        # unknown entry
+        entry = sys_dic.unknowns.get(u'HIRAGANA')[0]
+        self.assertTrue(type(entry[3]) is str)
+        self.assertTrue(type(entry[0]) is int)
+        self.assertTrue(type(entry[1]) is int)
+        self.assertTrue(type(entry[2]) is int)
+
+        # mmap dict etnry
+        matcher = Matcher(all_fstdata())
+        mmap_dic = MMapSystemDictionary.instance()
+        entry = mmap_dic.lookup(u'すもも'.encode('utf8'), matcher)[0]
+        self.assertTrue(type(entry[1]) is str)
+        self.assertTrue(type(entry[0]) is int)
+        self.assertTrue(type(entry[2]) is int)
+        self.assertTrue(type(entry[3]) is int)
+        self.assertTrue(type(entry[4]) is int)
+
+        entry_extra = mmap_dic.lookup_extra(entry[0])
+        self.assertTrue(type(entry_extra[0]) is str)
+        self.assertTrue(type(entry_extra[1]) is str)
+        self.assertTrue(type(entry_extra[2]) is str)
+        self.assertTrue(type(entry_extra[3]) is str)
+        self.assertTrue(type(entry_extra[4]) is str)
+        self.assertTrue(type(entry_extra[5]) is str)
+
+    def test_dictionary_cache(self):
+        matcher = Matcher(all_fstdata())
+        sys_dic = SystemDictionary.instance()
+        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'), matcher)))
+        self.assertEqual(11, len(sys_dic.lookup('小書き'.encode('utf8'), matcher)))
+        self.assertEqual(11, len(sys_dic.lookup('小書きにしました'.encode('utf8'), matcher)))
+
+        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'), matcher)))
+        self.assertEqual(10, len(sys_dic.lookup('みんなと'.encode('utf8'), matcher)))
+
+        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'), matcher)))
+        self.assertEqual(2, len(sys_dic.lookup('叩く'.encode('utf8'), matcher)))


### PR DESCRIPTION
Closes #104 

In Janome 4.0.1, every Tokenizer object independently opens the binary dictionary files with `mmap=True` (default); this can cause 'Too many open files' errors when multiple Tokenizer objects are created.
This would be resolved by making `MMapSystemDictionary` singleton and reusing them across Tokenizers.

Reproducible test code
```python
# openfiles_mmap.py
import psutil
from janome.tokenizer import Tokenizer

tokenizers = []
for i in range(10):
    tokenizers.append(Tokenizer(mmap=True))
print('Created Tokenizers = %d' % len(tokenizers))

p = psutil.Process()
open_dic_files = list(filter(lambda x: x.path.find('janome/sysdic') >= 0, p.open_files()))

print('Opened dictionary files = %d' % len(open_dic_files))
```

With janome 4.0.1:
```
$ python openfiles_mmap.py 
Created Tokenizers = 10
Opened dictionary files = 400
```

With this PR:
```
$ python openfiles_mmap.py 
Created Tokenizers = 10
Opened dictionary files = 40
```