### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+* 0.4.3 (yyyy.mm.dd)
+  - #112: Add GitHub URL for PyPi. (@andriyor)
+
 * 0.4.2 (2022.02.23)
   - #90: Fix Analyzer usage. (@syou6162)
   - #92: Add version info. (@norihitoishida)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
     license='AL2',
     classifiers=classifiers,
     url='https://mocobeta.github.io/janome/en/',
+    project_urls={
+        'Source': 'https://github.com/mocobeta/janome',
+    },
     packages=['janome', 'janome.sysdic'],
     package_data={'janome.sysdic': ['fst.data*']},
     scripts=['bin/janome', 'bin/janome.bat'],


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)