### PR TITLE
Add word filters

### DIFF
--- a/janome/tokenfilter.py
+++ b/janome/tokenfilter.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Iterator, Tuple, Any
+from typing import Iterator, Tuple, Any, List, Dict
 
 from janome.tokenizer import Token
 
@@ -76,7 +76,7 @@ class POSStopFilter(TokenFilter):
     Added in *version 0.3.4*
     """
 
-    def __init__(self, pos_list: list[str]):
+    def __init__(self, pos_list: List[str]):
         """
         Initialize POSStopFilter object.
 
@@ -102,7 +102,7 @@ class POSKeepFilter(TokenFilter):
     Added in *version 0.3.4*
     """
 
-    def __init__(self, pos_list: list[str]):
+    def __init__(self, pos_list: List[str]):
         """
         Initialize POSKeepFilter object.
 
@@ -242,7 +242,7 @@ class TokenCountFilter(TokenFilter):
         self.sorted = sorted
 
     def apply(self, tokens: Iterator[Token]) -> Iterator[Tuple[str, int]]:
-        token_counts: dict[str, int] = defaultdict(int)
+        token_counts: Dict[str, int] = defaultdict(int)
         for token in tokens:
             token_counts[getattr(token, self.att)] += 1
         if self.sorted:

--- a/janome/tokenfilter.py
+++ b/janome/tokenfilter.py
@@ -123,7 +123,7 @@ class WordStopFilter(TokenFilter):
     Added in *version 0.5.0*
     """
 
-    def __init__(self, stop_words: list[str]):
+    def __init__(self, stop_words: List[str]):
         """
         Initialize WordStopFilter object.
 
@@ -145,7 +145,7 @@ class WordKeepFilter(TokenFilter):
     Added in *version 0.5.0*
     """
 
-    def __init__(self, keep_words: list[str]) -> None:
+    def __init__(self, keep_words: List[str]) -> None:
         """
         Initialize WordKeepFilter object.
 

--- a/janome/tokenfilter.py
+++ b/janome/tokenfilter.py
@@ -14,9 +14,9 @@
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Iterator, List, Dict, Tuple, Any
+from typing import Iterator, Tuple, Any
 
-from .tokenizer import Token
+from janome.tokenizer import Token
 
 
 class TokenFilter(ABC):
@@ -66,7 +66,7 @@ class UpperCaseFilter(TokenFilter):
 
 
 class POSStopFilter(TokenFilter):
-    u"""
+    """
     A POSStopFilter removes tokens associated with part-of-speech tags
     listed in the stop tags list and keeps other tokens.
 
@@ -76,7 +76,7 @@ class POSStopFilter(TokenFilter):
     Added in *version 0.3.4*
     """
 
-    def __init__(self, pos_list: List[str]):
+    def __init__(self, pos_list: list[str]):
         """
         Initialize POSStopFilter object.
 
@@ -102,7 +102,7 @@ class POSKeepFilter(TokenFilter):
     Added in *version 0.3.4*
     """
 
-    def __init__(self, pos_list: List[str]):
+    def __init__(self, pos_list: list[str]):
         """
         Initialize POSKeepFilter object.
 
@@ -113,6 +113,49 @@ class POSKeepFilter(TokenFilter):
     def apply(self, tokens: Iterator[Token]) -> Iterator[Token]:
         for token in tokens:
             if any(token.part_of_speech.startswith(pos) for pos in self.pos_list):
+                yield token
+
+
+class WordStopFilter(TokenFilter):
+    """
+    A WordStopFilter removes tokens whose surface form is listed in the stop words list.
+
+    Added in *version 0.5.0*
+    """
+
+    def __init__(self, stop_words: list[str]):
+        """
+        Initialize WordStopFilter object.
+
+        :param stop_words: stop words list.
+        """
+        self.stop_words = stop_words
+
+    def apply(self, tokens: Iterator[Token]) -> Iterator[Token]:
+        for token in tokens:
+            if token.surface in self.stop_words:
+                continue
+            yield token
+
+
+class WordKeepFilter(TokenFilter):
+    """
+    A WordKeepFilter keeps tokens whose surface form is listed in the keep words list.
+
+    Added in *version 0.5.0*
+    """
+
+    def __init__(self, keep_words: list[str]) -> None:
+        """
+        Initialize WordKeepFilter object.
+
+        :param keep_words: keep words list.
+        """
+        self.keep_words = keep_words
+
+    def apply(self, tokens: Iterator[Token]) -> Iterator[Token]:
+        for token in tokens:
+            if token.surface in self.keep_words:
                 yield token
 
 
@@ -199,7 +242,7 @@ class TokenCountFilter(TokenFilter):
         self.sorted = sorted
 
     def apply(self, tokens: Iterator[Token]) -> Iterator[Tuple[str, int]]:
-        token_counts: Dict[str, int] = defaultdict(int)
+        token_counts: dict[str, int] = defaultdict(int)
         for token in tokens:
             token_counts[getattr(token, self.att)] += 1
         if self.sorted:

--- a/tests/test_tokenfilter.py
+++ b/tests/test_tokenfilter.py
@@ -20,6 +20,8 @@ from janome.tokenfilter import (
     UpperCaseFilter,
     POSStopFilter,
     POSKeepFilter,
+    WordStopFilter,
+    WordKeepFilter,
     CompoundNounFilter,
     ExtractAttributeFilter,
     TokenCountFilter
@@ -59,6 +61,16 @@ class TestTokenFilter(unittest.TestCase):
         tf = POSKeepFilter(['名詞,固有名詞', '動詞,自立'])
         tokens = tf.apply(self.t.tokenize('東京駅で降りる'))
         self.assertEqual(['名詞,固有名詞,地域,一般', '動詞,自立,*,*'], list(map(lambda token: token.part_of_speech, tokens)))
+
+    def test_word_stop_filter(self):
+        tf = WordStopFilter(['東京', '駅'])
+        tokens = tf.apply(self.t.tokenize('東京駅で降りる'))
+        self.assertEqual(['で', '降りる'], list(map(lambda token: token.surface, tokens)))
+
+    def test_word_keep_filter(self):
+        tf = WordKeepFilter(['東京', '駅'])
+        tokens = tf.apply(self.t.tokenize('東京駅で降りる'))
+        self.assertEqual(['東京', '駅'], list(map(lambda token: token.surface, tokens)))
 
     def test_compound_noun_filter(self):
         tf = CompoundNounFilter()


### PR DESCRIPTION
This adds two new token filters.

1. `WordStopFilter` removes tokens whose surface form is listed in the stop words list.
2. `WordKeepFilter` keeps tokens whose surface form is listed in the keep words list.

See the tests for the usage.