### PR TITLE
Housekeeping for latest python/tooling

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -r requirements-dev.txt
+        python setup.py develop
         python -m unittest discover tests/
 
   check:
@@ -38,6 +39,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -r requirements-dev.txt
+        python setup.py develop
         python -m unittest discover tests/
         coverage run -m unittest discover tests
     - name: Coveralls

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Test
       run: |
         pip install --upgrade pip
-        pip install --upgrade setuptools
         pip install -r requirements-dev.txt
         python setup.py test
 
@@ -38,7 +37,6 @@ jobs:
     - name: Unit tests for coverage
       run: |
         pip install --upgrade pip
-        pip install --upgrade setuptools
         pip install -r requirements-dev.txt
         python setup.py develop
         coverage run -m unittest discover tests

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -r requirements-dev.txt
-        python setup.py test
+        python -m unittest discover tests/
 
   check:
 
@@ -38,7 +38,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -r requirements-dev.txt
-        python setup.py develop
+        python -m unittest discover tests/
         coverage run -m unittest discover tests
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Steps to contribute
   $ python -m venv .venv
   $ . .venv/bin/activate
   (.venv) $ pip install -r requirements-dev.txt
+  (.venv) $ pip install -e .
   ```
 
 3. (Optional) Build and validate the built-in dictionary.
@@ -25,7 +26,7 @@ Steps to contribute
   $ cd ..
   $ rm -rf sysdic; unzip ./ipadic/sysdic.zip    // extract the built-in dictionary to janome root
   $ . .venv/bin/activate
-  (.venv) $ python setup.py develop    // install janome module for development
+  (.venv) $ pip install -e .   // install janome module for development
   (.venv) $ cd ipadic 
   (.venv) $ ./validate.sh mecab-ipadic-2.7.0-20070801
   ```

--- a/janome/charfilter.py
+++ b/janome/charfilter.py
@@ -63,7 +63,7 @@ class UnicodeNormalizeCharFilter(CharFilter):
     Added in *version 0.3.4*
     """
 
-    def __init__(self, form: str = 'NFKC'):
+    def __init__(self, form = 'NFKC'):
         """
         Initialize UnicodeNormalizeCharFilter with normalization form.
 

--- a/janome/charfilter.py
+++ b/janome/charfilter.py
@@ -63,7 +63,7 @@ class UnicodeNormalizeCharFilter(CharFilter):
     Added in *version 0.3.4*
     """
 
-    def __init__(self, form = 'NFKC'):
+    def __init__(self, form='NFKC'):
         """
         Initialize UnicodeNormalizeCharFilter with normalization form.
 

--- a/janome/tokenizer.py
+++ b/janome/tokenizer.py
@@ -286,9 +286,9 @@ class Tokenizer(object):
         else:
             tokens = []
             for node in min_cost_path[1:-1]:
-                if type(node) == SurfaceNode and node.node_type == NodeType.SYS_DICT:
+                if type(node) is SurfaceNode and node.node_type is NodeType.SYS_DICT:
                     tokens.append(Token(node, self.sys_dic.lookup_extra(node.num)))
-                elif type(node) == SurfaceNode and node.node_type == NodeType.USER_DICT:
+                elif type(node) is SurfaceNode and node.node_type is NodeType.USER_DICT:
                     tokens.append(Token(node, self.user_dic.lookup_extra(node.num)))
                 else:
                     tokens.append(Token(node))

--- a/release-memo.md
+++ b/release-memo.md
@@ -9,7 +9,7 @@ git switch -c release-x.x.x
 2. Make sure that all tests are OK.
 
 ```
-python setup.py test
+python -m unittest discover tests/
 ```
 
 3. Fix version and create a new tag for the release.
@@ -25,8 +25,7 @@ git push --tags
 
 ```
 rm dist/*
-python setup.py sdist
-python setup.py bdist_wheel --universal
+python -m build
 ```
 
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ twine
 wheel
 psutil
 coverage
+setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ wheel
 psutil
 coverage
 setuptools
+build

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,11 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: Japanese",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10"
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 setup(


### PR DESCRIPTION
- Don't run `setup.py` as install/build command; instead, run `pip install` and `build`. This change is suggested in https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
- Add the latest python versions and remove old runtimes in test matrix
- Minor syntax changes to fix lint erros