### PR TITLE
Fix syspath for autodoc

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -19,7 +19,7 @@
 #
 import os
 import sys
-sys.path.insert(0, '/home/moco/repo/janome')
+sys.path.insert(0, '../..')
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Fix sys.path for Sphinx autodoc extention so that the API doc can be generated with a CI workflow.