### PR TITLE
Move docs to mocobeta.dev domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ Janome is a Japanese morphological analysis engine written in pure Python.
 
 General documentation:
 
-https://mocobeta.github.io/janome/en/ (English)
+https://janome.mocobeta.dev/janome/en/ (English)
 
-https://mocobeta.github.io/janome/ (Japanese)
+https://janome.mocobeta.dev/janome/ja (Japanese)
 
 Requirements
 =============

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ Janome is a Japanese morphological analysis engine written in pure Python.
 
 General documentation:
 
-https://janome.mocobeta.dev/janome/en/ (English)
+https://janome.mocobeta.dev/en/ (English)
 
-https://janome.mocobeta.dev/janome/ja (Japanese)
+https://janome.mocobeta.dev/ja/ (Japanese)
 
 Requirements
 =============

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -8,9 +8,9 @@ Janome API reference
 
 For general documentation see:
 
-`http://mocobeta.github.io/janome/en/ <http://mocobeta.github.io/janome/en/>`_ (en)
+`http://janome.mocobeta.dev/en/ <http://janome.mocobeta.dev/en/>`_ (en)
 
-`http://mocobeta.github.io/janome/ <http://mocobeta.github.io/janome/>`_ (ja)
+`http://janome.mocobeta.dev/ja/ <http://janome.mocobeta.dev/ja/>`_ (ja)
 
 .. toctree::
    :maxdepth: 4

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -11,3 +11,7 @@ pip install -r requirements-docs.txt
 cd ${BASEDIR}/api && make clean && make html
 cd ${BASEDIR}/ja && make clean && make html
 cd ${BASEDIR}/en && make clean && make html
+
+mkdir -p ${BASEDIR}/build/reference && cp -Rp ${BASEDIR}/api/_build/html/* ${BASEDIR}/build/reference
+mkdir -p ${BASEDIR}/build/ja && cp -Rp ${BASEDIR}/ja/_build/html/* ${BASEDIR}/build/ja
+mkdir -p ${BASEDIR}/build/en && cp -Rp ${BASEDIR}/en/_build/html/* ${BASEDIR}/build/en

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -14,7 +14,7 @@
 Welcome to janome's documentation! (English)
 =============================================
 
-`日本語 <http://mocobeta.github.io/janome/>`_
+`日本語 <http://janome.mocobeta.dev/ja/>`_
 
 What's Janome?
 --------------
@@ -39,7 +39,7 @@ If you like janome, please star the repository! :)
 API reference
 -------------
 
-`https://mocobeta.github.io/janome/api/ <http://mocobeta.github.io/janome/api/>`_
+`https://janome.mocobeta.dev/reference/ <http://janome.mocobeta.dev/reference/>`_
 
 Requirements
 ------------
@@ -70,7 +70,7 @@ Usage
 
 Create janome.tokenizer.Tokenizer object and call tokenize() method with the sentences you want to analyze.
 
-The return value is a gnerator of Token objects. Token includes morphologic information such as surface form, part-of-speech. See `reference <http://mocobeta.github.io/janome/api/janome.html#janome.tokenizer.Token>`_ for more details.
+The return value is a gnerator of Token objects. Token includes morphologic information such as surface form, part-of-speech. See `reference <http://janome.mocobeta.dev/reference/janome.html#janome.tokenizer.Token>`_ for more details.
 
 ::
 
@@ -182,7 +182,7 @@ Pre-compiled user dictionary
 
 With large user dictionary, it can take much time to convert CSV file to the binary data structure. You can compile the user dictionary in advance and use that at runtime.
 
-For now, there is no tools for compiling user dictionary. Use `APIs <http://mocobeta.github.io/janome/api/janome.html#janome.dic.UserDictionary>`_ as below. ``progress_handler`` option is supported in v0.4.1 or above.
+For now, there is no tools for compiling user dictionary. Use `APIs <http://janome.mocobeta.dev/reference/janome.html#janome.dic.UserDictionary>`_ as below. ``progress_handler`` option is supported in v0.4.1 or above.
 
 How to compile user dictionary (MeCab IPADIC format): ::
 
@@ -217,9 +217,9 @@ Once compiling has been successfully completed, the data is saved in ``/tmp/user
 
 Analyzer framework is for pre- and post- processing. Analyzer framework includes following classes.
 
-* `CharFilter <http://mocobeta.github.io/janome/api/janome.html#janome.charfilter.CharFilter>`_ class performs pre-processing such as character normalization.
-* `TokenFilter <http://mocobeta.github.io/janome/api/janome.html#janome.tokenfilter.TokenFilter>`_ class performs post-processing such as lowercase/uppercase conversion, token filtering by POS tags.
-* `Analyzer <http://mocobeta.github.io/janome/api/janome.html#janome.analyzer.Analyzer>`_ class combines CharFilters, a Tokenizer and TokenFilters to assemble custom analysis chain.
+* `CharFilter <http://janome.mocobeta.dev/reference/janome.html#janome.charfilter.CharFilter>`_ class performs pre-processing such as character normalization.
+* `TokenFilter <http://janome.mocobeta.dev/reference/janome.html#janome.tokenfilter.TokenFilter>`_ class performs post-processing such as lowercase/uppercase conversion, token filtering by POS tags.
+* `Analyzer <http://janome.mocobeta.dev/reference/janome.html#janome.analyzer.Analyzer>`_ class combines CharFilters, a Tokenizer and TokenFilters to assemble custom analysis chain.
 
 Analyzser usage
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/ja/index.rst
+++ b/docs/ja/index.rst
@@ -13,7 +13,7 @@
 Welcome to janome's documentation! (Japanese)
 ==============================================
 
-`English <http://mocobeta.github.io/janome/en/>`_
+`English <http://janome.mocobeta.dev/en/>`_
 
 Janome とは
 -----------
@@ -38,7 +38,7 @@ Janome (蛇の目; ◉) は，Pure Python で書かれた，辞書内包の形�
 API リファレンス
 --------------------------
 
-`https://mocobeta.github.io/janome/api/ <http://mocobeta.github.io/janome/api/>`_
+`https://janome.mocobeta.dev/reference/ <http://janome.mocobeta.dev/reference/>`_
 
 
 動作に必要なソフトウェア
@@ -83,7 +83,7 @@ PyPI
 
 janome.tokenizer パッケージの Tokenizer オブジェクトを作り，tokenize() メソッドに解析したい文字列を渡します。
 
-戻り値は Token オブジェクトのイテレータ (generator) です。Token は表層形や品詞といった形態素情報を含みます。詳しくは `リファレンス <http://mocobeta.github.io/janome/api/janome.html#janome.tokenizer.Token>`_ を参照してください。
+戻り値は Token オブジェクトのイテレータ (generator) です。Token は表層形や品詞といった形態素情報を含みます。詳しくは `リファレンス <http://janome.mocobeta.dev/reference/janome.html#janome.tokenizer.Token>`_ を参照してください。
 
 ::
 
@@ -201,7 +201,7 @@ user_simpledic.csv ::
 
 ユーザー定義辞書は，巨大になるとバイナリコンパイルに時間がかかるため，あらかじめコンパイルしておき，コンパイル済みの辞書を使うことも可能です。
 
-現在のところ，コンパイルのためのツールはありませんが， `API <http://mocobeta.github.io/janome/api/janome.html#janome.dic.UserDictionary>`_ を使ってコンパイルが行えます。 ``progress_handler`` オプションは v0.4.1 以上でサポートされます。
+現在のところ，コンパイルのためのツールはありませんが， `API <http://janome.mocobeta.dev/reference/janome.html#janome.dic.UserDictionary>`_ を使ってコンパイルが行えます。 ``progress_handler`` オプションは v0.4.1 以上でサポートされます。
 
 辞書のコンパイル(MeCab IPADIC format) ::
 
@@ -236,9 +236,9 @@ Analyzer フレームワーク (v0.3.4 以上)
 
 Analyzer は，形態素解析の前処理・後処理をテンプレ化するためのフレームワークです。Analyzer フレームワークは下記のクラスを含みます。
 
-* 文字の正規化などの前処理を行う `CharFilter <http://mocobeta.github.io/janome/api/janome.html#janome.charfilter.CharFilter>`_ クラス
-* 小文字化，品詞によるトークンのフィルタリングなど，形態素解析後の後処理を行う `TokenFilter <http://mocobeta.github.io/janome/api/janome.html#janome.tokenfilter.TokenFilter>`_ クラス
-* CharFilter, Tokenizer, TokenFilter を組み合わせてカスタム解析フローを組み立てる `Analyzer <http://mocobeta.github.io/janome/api/janome.html#janome.analyzer.Analyzer>`_ クラス
+* 文字の正規化などの前処理を行う `CharFilter <http://janome.mocobeta.dev/reference/janome.html#janome.charfilter.CharFilter>`_ クラス
+* 小文字化，品詞によるトークンのフィルタリングなど，形態素解析後の後処理を行う `TokenFilter <http://janome.mocobeta.dev/reference/janome.html#janome.tokenfilter.TokenFilter>`_ クラス
+* CharFilter, Tokenizer, TokenFilter を組み合わせてカスタム解析フローを組み立てる `Analyzer <http://janome.mocobeta.dev/reference/janome.html#janome.analyzer.Analyzer>`_ クラス
 
 Analyzer の使い方
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/ja/json-ld.txt
+++ b/docs/ja/json-ld.txt
@@ -3,7 +3,7 @@
   "@context": "http://schema.org",
   "@type": "TechArticle",
   "image": [
-    "https://mocobeta.github.io/janome/_images/janome_small.jpg"
+    "https://janome.mocobeta.dev/ja/_images/janome_small.jpg"
    ],
   "headline": "Welcome to janome's documentation! (Japanese)",
   "datePublished": "2015-04-08T00:00:00+09:00",


### PR DESCRIPTION
Move docs to `janome.mocobeta.dev`
- API reference: https://janome.mocobeta.dev/reference/
- Doc (en): https://janome.mocobeta.dev/en/
- Doc (ja): https://janome.mocobeta.dev/ja/